### PR TITLE
Add support for k6 checks grouped by check's tag and status

### DIFF
--- a/pkg/statsd/helper_test.go
+++ b/pkg/statsd/helper_test.go
@@ -88,6 +88,8 @@ func baseTest(t *testing.T,
 	myCheck, err := registry.NewMetric("my_check", metrics.Rate)
 	require.NoError(t, err)
 
+	statsdTagsEnabled := collector.config.EnableTags.Bool
+
 	testMatrix := []struct {
 		input  []metrics.SampleContainer
 		output string
@@ -141,7 +143,13 @@ func baseTest(t *testing.T,
 					"check": "max>100",
 				}),
 			},
-			output: "testing.things.check.max<100.pass:1|c\ntesting.things.check.max>100.fail:1|c",
+			output: func() string {
+				if statsdTagsEnabled {
+					return "testing.things.my_check:1|c\ntesting.things.my_check:1|c"
+				} else {
+					return "testing.things.check.max<100.pass:1|c\ntesting.things.check.max>100.fail:1|c"
+				}
+			}(),
 		},
 	}
 	for _, test := range testMatrix {

--- a/pkg/statsd/output.go
+++ b/pkg/statsd/output.go
@@ -47,7 +47,7 @@ type Output struct {
 func (o *Output) dispatch(entry metrics.Sample) error {
 	var tagList []string
 	if o.config.EnableTags.Bool {
-		tagList = processTags(o.config.TagBlocklist, entry.Tags.Map())
+		tagList = processTags(o.config.TagBlocklist, maybeAddStatusTag(o, entry))
 	}
 
 	switch entry.Metric.Type {
@@ -59,17 +59,47 @@ func (o *Output) dispatch(entry metrics.Sample) error {
 		return o.client.Gauge(entry.Metric.Name, entry.Value, tagList, 1)
 	case metrics.Rate:
 		if check, ok := entry.Tags.Get("check"); ok {
-			return o.client.Count(
-				checkToString(check, entry.Value),
-				1,
-				tagList,
-				1,
-			)
+			if o.config.EnableTags.Bool {
+				return o.client.Count(
+					entry.Metric.Name,
+					1,
+					tagList,
+					1,
+				)
+			} else {
+				return o.client.Count(
+					checkToString(check, entry.Value),
+					1,
+					tagList,
+					1,
+				)
+			}
 		}
 		return o.client.Count(entry.Metric.Name, int64(entry.Value), tagList, 1)
 	default:
 		return fmt.Errorf("unsupported metric type %s", entry.Metric.Type)
 	}
+}
+
+func maybeAddStatusTag(o *Output, entry metrics.Sample) map[string]string {
+	_, statusOk := entry.Tags.Get("check_status")
+	_, checkOk := entry.Tags.Get("check")
+
+	if checkOk && !statusOk {
+		tagsMap := entry.Tags.Map()
+
+		checkStatus := "pass"
+
+		if entry.Value == 0 {
+			checkStatus = "fail"
+		}
+
+		tagsMap["check_status"] = checkStatus
+
+		return tagsMap
+	}
+
+	return entry.Tags.Map()
 }
 
 func checkToString(check string, value float64) string {

--- a/pkg/statsd/output_test.go
+++ b/pkg/statsd/output_test.go
@@ -55,7 +55,7 @@ func TestStatsdEnabledTags(t *testing.T) {
 			"namespace": "%s",
 			"bufferSize": %d,
 			"pushInterval": "%s",
-			"tagBlocklist": ["tag1", "tag2"],
+			"tagBlocklist": ["tag1", "tag2", "check_status"],
 			"enableTags": true
 		}`, addr.String, namespace.String, bufferSize.Int64, pushInterval.Duration.String())),
 			})


### PR DESCRIPTION
Right now `checks` metrics appear in this format `k6.check.<check_name>.<pass|fail>` for each check metric separately, and according to [original implementation](https://github.com/LeonAdato/xk6-output-statsd/blob/main/pkg/statsd/output.go#L75-L81) which is more reasonable when `K6_STATSD_ENABLE_TAGS` = `false`.

This fork adds `check_status` tag and groups everything under `checks` metric when `K6_STATSD_ENABLE_TAGS` = `true` for ease of use in DataDog. 

This is how a similar chart looks with InfluxDB output and Grafana:

![image](https://github.com/svsool/xk6-output-statsd/assets/1452141/e0759259-a2ee-401f-988e-6f9c8c00fdcd)

Before:

<img src="https://github.com/svsool/xk6-output-statsd/assets/1452141/82f2752a-4ae7-4268-909e-add6306682a7" width="520" />

After:

![image](https://github.com/svsool/xk6-output-statsd/assets/1452141/4de47279-15d2-4cb1-a4fb-b37c53d28f6d)




